### PR TITLE
Make TypeEq and its inner types interfaces

### DIFF
--- a/src/main/java/org/derive4j/hkt/TypeEq.java
+++ b/src/main/java/org/derive4j/hkt/TypeEq.java
@@ -13,28 +13,149 @@ package org.derive4j.hkt;
  * @see <a href="http://typelevel.org/blog/2014/09/20/higher_leibniz.html">Higher TypeEq</a>
  * @see <a href="https://github.com/ekmett/eq">Leibnizian type equality in Haskell</a>
  */
-public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
+@SuppressWarnings("Convert2MethodRef")
+public interface TypeEq<A, B> extends  __2<TypeEq.µ, A, B> {
+  /** Type constructor witness of TypeEq. */
+  enum µ {}
 
-  /** Serve as type constructor witness of TypeEq. */
-  public enum µ {}
+  /**
+   * Leibnizian equality states that two things are equal if you can substitute one for the other in all contexts.
+   *
+   * @param fa a term whose type last parameter is {@link A}.
+   * @param <f> type constructor witness of {@code fa} type.
+   * @return the input value with {@link A} substituted by {@link B} in its type.
+   */
+  <f> __<f, B> subst(__<f, A> fa);
 
-  private TypeEq() {
+  /**
+   * If two things are equal you can convert one to the other (safe cast).
+   *
+   * @param a a value of type {@link A} that will be coerced into type {@link B}.
+   * @return the same value, after type coercion.
+   */
+  default B coerce(A a) {
+    return Id.narrow(subst((Id<A>) () -> a)).__();
+  }
+
+  /**
+   * Equality is transitive.
+   *
+   * @param that another TypeEq to compose with.
+   * @param <C> left operand of the transitive type equality.
+   * @return the composition of the TypeEq instances.
+   */
+  default <C> TypeEq<C, B> compose(TypeEq<C, A> that) {
+    return TypeEq.ofHkt(subst(that));
+  }
+
+  /**
+   * Equality is transitive.
+   *
+   * @param that another TypeEq to be composed with.
+   * @param <C> right operand of the transitive type equality.
+   * @return the composition of the TypeEq instances.
+   */
+  default <C> TypeEq<A, C> andThen(TypeEq<B, C> that) {
+    return that.compose(this);
+  }
+
+  /**
+   * Equality is symmetric.
+   *
+   * @return the type equality seen from the other side.
+   */
+  default TypeEq<B, A> symm() {
+    final Symm<A, A> symm = () -> refl();
+
+    return Symm.narrow(subst(symm)).__();
+  }
+
+  /**
+   * The type equality can be lifted into any type constructor.
+   *
+   * @param <f> a type constructor witness.
+   * @return the type equality in the context of the specified type constructor.
+   */
+  default <f> TypeEq<__<f, A>, __<f, B>> lift() {
+    final Lift<f, A, A> _refl = () -> refl();
+
+    return Lift.narrow(subst(_refl)).__();
+  }
+
+  /**
+   * The type equality can be lifted into any type constructor, at any position.
+   *
+   * @param <f> a type constructor witness.
+   * @param <C> the last type variable (not substituted).
+   * @return the type equality in the context of the specified type constructor.
+   */
+  default <f, C> TypeEq<__<__<f, A>, C>, __<__<f, B>, C>> lift2() {
+    return lift2(refl());
+  }
+
+  /**
+   * Type equalities can be lifted into any type constructor, at any positions.
+   *
+   * @param cd a type equality witness for last type variable of any type constructor.
+   * @param <C> the last type variable before substitution.
+   * @param <D> the last type variable after substitution.
+   * @return a factory to lift the TypeEq instances into any type constructor.
+   */
+  default <f, C, D> TypeEq<__<__<f, A>, C>, __<__<f, B>, D>> lift2(TypeEq<C, D> cd) {
+    final Lift2_1<f, A, C, A> _refl = () -> refl();
+
+    final Lift2_1<f, A, C, B> lift2_1 = Lift2_1.narrow(subst(_refl));
+
+    final Lift2<f, A, C, B, C> lift2 = () -> lift2_1.__();
+
+    return Lift2.narrow(cd.subst(lift2)).__();
+  }
+
+  /**
+   * The type equality can be lifted into any type constructor, at any position.
+   *
+   * @param <f> a type constructor witness.
+   * @param <C> the before last type variable (not substituted).
+   * @param <D> the last type variable (not substituted).
+   * @return the type equality in the context of the specified type constructor.
+   */
+  default <f, C, D> TypeEq<__<__<__<f, A>, C>, D>, __<__<__<f, B>, C>, D>> lift3() {
+    return lift3(refl(), refl());
+  }
+
+  /**
+   * Type equalities can be lifted into any type constructor, at any positions.
+   *
+   * @param cd a type equality witness for before last type variable of any type constructor.
+   * @param ef a type equality witness for last type variable of any type constructor.
+   * @param <C> the before last type variable before substitution.
+   * @param <D> the before last type variable after substitution.
+   * @param <E> the last type variable before substitution.
+   * @param <F> the last type variable after substitution.
+   * @return a factory to lift the TypeEq instances into any type constructor.
+   */
+  default <f, C, D, E, F> TypeEq<__<__<__<f, A>, C>, E>, __<__<__<f, B>, D>, F>> lift3(TypeEq<C, D> cd
+    , TypeEq<E, F> ef) {
+    final Lift3_1<f, A, C, E, A> _refl = () -> refl();
+
+    final Lift3_1<f, A, C, E, B> lift3_1 = Lift3_1.narrow(subst(_refl));
+
+    final Lift3_2<f, A, C, E, B, C> lift3_2 = () -> lift3_1.__();
+
+    final Lift3_2<f, A, C, E, B, D> lift3_2_1 = Lift3_2.narrow(cd.subst(lift3_2));
+
+    final Lift3<f, A, C, E, B, D, E> lift3 = () -> lift3_2_1.__();
+
+    return Lift3.narrow(ef.subst(lift3)).__();
   }
 
   /**
    * Equality is reflexive: a type is equal to itself.
    *
-   * @param <A> any type.
+   * @param <T> any type.
    * @return a TypeEq representing the reflexive equality.
    */
-  public static <A> TypeEq<A, A> refl() {
-    // The only possible implementation, the identity:
-    return new TypeEq<A, A>() {
-      @Override public <f> __<f, A> subst(final __<f, A> fa) {
-        return fa;
-      }
-    };
-  }
+  static <T> TypeEq<T, T> refl() { return HktId::id; }
 
   /**
    * Recover the concrete type of a higher kinded TypeEq value.
@@ -45,7 +166,7 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @param <B> a type {@link B} which is guaranteed to be same as {@link A}.
    * @return the same TypeEq, casted to the corresponding concrete type.
    */
-  public static <A, B> TypeEq<A, B> ofHkt(__<__<TypeEq.µ, A>, B> hkTypeEq) {
+  static <A, B> TypeEq<A, B> ofHkt(__<__<TypeEq.µ, A>, B> hkTypeEq) {
     return (TypeEq<A, B>) hkTypeEq;
   }
 
@@ -60,14 +181,14 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <A, B> TypeEq<__<__<TypeEq.µ, A>, B>, TypeEq<A, B>> hkt() {
-    return (TypeEq) refl();
+  static <A, B> TypeEq<__<__<TypeEq.µ, A>, B>, TypeEq<A, B>> hkt() {
+    return (TypeEq) TypeEq.refl();
   }
 
   /**
    * Safe cast to __2. (guaranteed by the hkt type checker).
    */
-  public static <f, A, B> __2<f, A, B> as__2(__<__<f, A>, B> fab) {
+  static <f, A, B> __2<f, A, B> as__2(__<__<f, A>, B> fab) {
     return (__2<f, A, B>) fab;
   }
 
@@ -81,14 +202,14 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <f, A, B> TypeEq<__<__<f, A>, B>, __2<f, A, B>> __2() {
+  static <f, A, B> TypeEq<__<__<f, A>, B>, __2<f, A, B>> __2() {
     return (TypeEq) TypeEq.refl();
   }
 
   /**
    * Safe cast to __3. (guaranteed by the hkt type checker).
    */
-  public static <f, A, B, C> __3<f, A, B, C> as__3(__<__<__<f, A>, B>, C> fabc) {
+  static <f, A, B, C> __3<f, A, B, C> as__3(__<__<__<f, A>, B>, C> fabc) {
     return (__3<f, A, B, C>) fabc;
   }
 
@@ -103,14 +224,14 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <f, A, B, C> TypeEq<__<__<__<f, A>, B>, C>, __3<f, A, B, C>> __3() {
+  static <f, A, B, C> TypeEq<__<__<__<f, A>, B>, C>, __3<f, A, B, C>> __3() {
     return (TypeEq) TypeEq.refl();
   }
 
   /**
    * Safe cast to __4. (guaranteed by the hkt type checker).
    */
-  public static <f, A, B, C, D> __4<f, A, B, C, D> as__4(__<__<__<__<f, A>, B>, C>, D> fabcd) {
+  static <f, A, B, C, D> __4<f, A, B, C, D> as__4(__<__<__<__<f, A>, B>, C>, D> fabcd) {
     return (__4<f, A, B, C, D>) fabcd;
   }
 
@@ -122,14 +243,14 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <f, A, B, C, D> TypeEq<__<__<__<__<f, A>, B>, C>, D>, __4<f, A, B, C, D>> __4() {
+  static <f, A, B, C, D> TypeEq<__<__<__<__<f, A>, B>, C>, D>, __4<f, A, B, C, D>> __4() {
     return (TypeEq) TypeEq.refl();
   }
 
   /**
    * Safe cast to __5. (guaranteed by the hkt type checker).
    */
-  public static <f, A, B, C, D, E> __5<f, A, B, C, D, E> as__5(__<__<__<__<__<f, A>, B>, C>, D>, E> fabcde) {
+  static <f, A, B, C, D, E> __5<f, A, B, C, D, E> as__5(__<__<__<__<__<f, A>, B>, C>, D>, E> fabcde) {
     return (__5<f, A, B, C, D, E>) fabcde;
   }
 
@@ -141,14 +262,14 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <f, A, B, C, D, E> TypeEq<__<__<__<__<__<f, A>, B>, C>, D>, E>, __5<f, A, B, C, D, E>> __5() {
+  static <f, A, B, C, D, E> TypeEq<__<__<__<__<__<f, A>, B>, C>, D>, E>, __5<f, A, B, C, D, E>> __5() {
     return (TypeEq) TypeEq.refl();
   }
 
   /**
    * Safe cast to __6. (guaranteed by the hkt type checker).
    */
-  public static <f, A, B, C, D, E, F> __6<f, A, B, C, D, E, F> as__6(__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F> fabcdef) {
+  static <f, A, B, C, D, E, F> __6<f, A, B, C, D, E, F> as__6(__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F> fabcdef) {
     return (__6<f, A, B, C, D, E, F>) fabcdef;
   }
 
@@ -160,15 +281,15 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <f, A, B, C, D, E, F> TypeEq<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, __6<f, A, B, C, D, E, F>> __6() {
+  static <f, A, B, C, D, E, F> TypeEq<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, __6<f, A, B, C, D, E, F>> __6() {
     return (TypeEq) TypeEq.refl();
   }
 
   /**
    * Safe cast to __7. (guaranteed by the hkt type checker).
    */
-  public static <f, A, B, C, D, E, F, G> __7<f, A, B, C, D, E, F, G> as__7(__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>
-      fabcdefg) {
+  static <f, A, B, C, D, E, F, G> __7<f, A, B, C, D, E, F, G> as__7(__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>
+                                                                      fabcdefg) {
     return (__7<f, A, B, C, D, E, F, G>) fabcdefg;
   }
 
@@ -180,7 +301,7 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <f, A, B, C, D, E, F, G> TypeEq<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, __7<f, A, B, C, D, E, F, G>> __7() {
+  static <f, A, B, C, D, E, F, G> TypeEq<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, __7<f, A, B, C, D, E, F, G>> __7() {
     return (TypeEq) TypeEq.refl();
   }
 
@@ -188,7 +309,7 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
   /**
    * Safe cast to __8. (guaranteed by the hkt type checker).
    */
-  public static <f, A, B, C, D, E, F, G, H> __8<f, A, B, C, D, E, F, G, H> as__8(__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H> fabcdefgh) {
+  static <f, A, B, C, D, E, F, G, H> __8<f, A, B, C, D, E, F, G, H> as__8(__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H> fabcdefgh) {
     return (__8<f, A, B, C, D, E, F, G, H>) fabcdefgh;
   }
 
@@ -200,7 +321,7 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <f, A, B, C, D, E, F, G, H> TypeEq<__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H>, __8<f, A, B, C, D, E, F, G, H>> __8() {
+  static <f, A, B, C, D, E, F, G, H> TypeEq<__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H>, __8<f, A, B, C, D, E, F, G, H>> __8() {
     return (TypeEq) TypeEq.refl();
   }
 
@@ -208,7 +329,7 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
   /**
    * Safe cast to __9. (guaranteed by the hkt type checker).
    */
-  public static <f, A, B, C, D, E, F, G, H, I> __9<f, A, B, C, D, E, F, G, H, I> as__9(__<__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H>, I> fabcdefghi) {
+  static <f, A, B, C, D, E, F, G, H, I> __9<f, A, B, C, D, E, F, G, H, I> as__9(__<__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H>, I> fabcdefghi) {
     return (__9<f, A, B, C, D, E, F, G, H, I>) fabcdefghi;
   }
 
@@ -220,281 +341,91 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <f, A, B, C, D, E, F, G, H, I> TypeEq<__<__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H>, I>, __9<f, A, B, C, D, E, F, G, H, I>> __9() {
+  static <f, A, B, C, D, E, F, G, H, I> TypeEq<__<__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H>, I>, __9<f, A, B, C, D, E, F, G, H, I>> __9() {
     return (TypeEq) TypeEq.refl();
   }
+}
 
-  /**
-   * Leibnizian equality states that two things are equal if you can substitute one for the other in all contexts.
-   *
-   * @param fa a term whose type last parameter is {@link A}.
-   * @param <f> type constructor witness of {@code fa} type.
-   * @return the input value with {@link A} substituted by {@link B} in its type.
-   */
-  public abstract <f> __<f, B> subst(__<f, A> fa);
+// ################ Type inference helpers
 
-  /**
-   * If two things are equal you can convert one to the other (safe cast).
-   *
-   * @param a a value of type {@link A} that will be coerced into type {@link B}.
-   * @return the same value, after type coercion.
-   */
-  public final B coerce(A a) {
-    return Identity.ofHkt(subst(new Identity<>(a))).runIdentity;
+interface HktId {
+  static <f, T> __<f, T> id(__<f, T> ft) { return ft; }
+}
+
+interface Id<A> extends __<Id.µ, A> {
+  enum µ {}
+
+  A __();
+
+  static <A> Id<A> narrow(__<Id.µ, A> a) { return (Id<A>) a; }
+}
+
+interface Symm<A, B> extends __2<Symm.µ, A, B> {
+  enum µ {}
+
+  TypeEq<B, A> __();
+
+  static <A, B> Symm<A, B> narrow(__<__<Symm.µ, A>, B> _lift) {
+    return (Symm<A, B>) _lift;
   }
+}
 
-  /**
-   * Equality is transitive.
-   *
-   * @param that another TypeEq to compose with.
-   * @param <C> left operand of the transitive type equality.
-   * @return the composition of the TypeEq instances.
-   */
-  public final <C> TypeEq<C, B> compose(TypeEq<C, A> that) {
-    return new TypeEq<C, B>() {
-      @Override public <f> __<f, B> subst(__<f, C> fa) {
-        return TypeEq.this.subst(that.subst(fa));
-      }
-    };
+interface Lift<f, A, B> extends __3<Lift.µ, f, A, B> {
+  enum µ {}
+
+  TypeEq<__<f, A>, __<f, B>> __();
+
+  static <f, A, X> Lift<f, A, X> narrow(__<__<__<Lift.µ, f>, A>, X> _lift) {
+    return (Lift<f, A, X>) _lift;
   }
+}
 
-  /**
-   * Equality is transitive.
-   *
-   * @param that another TypeEq to be composed with.
-   * @param <C> right operand of the transitive type equality.
-   * @return the composition of the TypeEq instances.
-   */
-  public final <C> TypeEq<A, C> andThen(TypeEq<B, C> that) {
-    return that.compose(this);
+interface Lift2_1<f, A, B, X> extends __4<Lift2_1.µ, f, A, B, X> {
+  enum µ {}
+
+  TypeEq<__<__<f, A>, B>, __<__<f, X>, B>> __();
+
+  static <f, A, B, X> Lift2_1<f, A, B, X> narrow(__<__<__<__<Lift2_1.µ, f>, A>, B>, X> lift1) {
+    return (Lift2_1<f, A, B, X>) lift1;
   }
+}
 
-  /**
-   * Equality is symmetric.
-   *
-   * @return the type equality seen from the other side.
-   */
-  public final TypeEq<B, A> symm() {
-    return Symm.ofHkt(subst(new Symm<>(refl()))).typeEq;
+interface Lift2<f, A, B, C, X> extends __5<Lift2.µ, f, A, B, C, X>  {
+  enum µ {}
+
+  TypeEq<__<__<f, A>, B>, __<__<f, C>, X>> __();
+
+  static <f, A, B, C, X> Lift2<f, A, B, C, X> narrow(__<__<__<__<__<Lift2.µ, f>, A>, B>, C>, X> lift2) {
+    return (Lift2<f, A, B, C, X>) lift2;
   }
+}
 
-  /**
-   * The type equality can be lifted into any type constructor.
-   *
-   * @param <f> a type constructor witness.
-   * @return the type equality in the context of the specified type constructor.
-   */
-  public final <f> TypeEq<__<f, A>, __<f, B>> lift() {
-    return Lift.ofHkt(subst(new Lift<>(TypeEq.<__<f, A>>refl()))).unlift;
+interface Lift3_1<f, A, B, C, X> extends __5<Lift3_1.µ, f, A, B, C, X> {
+  enum µ {}
+
+  TypeEq<__<__<__<f, A>, B>, C>, __<__<__<f, X>, B>, C>> __();
+
+  static <f, A, B, C, X> Lift3_1<f, A, B, C, X> narrow(__<__<__<__<__<Lift3_1.µ, f>, A>, B>, C>, X> lift3) {
+    return (Lift3_1<f, A, B, C, X>) lift3;
   }
+}
 
-  /**
-   * The type equality can be lifted into any type constructor, at any position.
-   *
-   * @param <f> a type constructor witness.
-   * @param <C> the last type variable (not substituted).
-   * @return the type equality in the context of the specified type constructor.
-   */
-  public final <f, C> TypeEq<__<__<f, A>, C>, __<__<f, B>, C>> lift2() {
-    return Lift2.ofHkt(subst(new Lift2<>(TypeEq.<__<__<f, A>, C>>refl()))).unlift2;
+interface Lift3_2<f, A, B, C, D, X> extends __6<Lift3_2.µ, f, A, B, C, D, X> {
+  enum µ {}
+
+  TypeEq<__<__<__<f, A>, B>, C>, __<__<__<f, D>, X>, C>> __();
+
+  static <f, A, B, C, D, X> Lift3_2<f, A, B, C, D, X> narrow(__<__<__<__<__<__<Lift3_2.µ, f>, A>, B>, C>, D>, X> lift3) {
+    return (Lift3_2<f, A, B, C, D, X>) lift3;
   }
+}
 
-  /**
-   * Type equalities can be lifted into any type constructor, at any positions.
-   *
-   * @param cd a type equality witness for last type variable of any type constructor.
-   * @param <C> the last type variable before substitution.
-   * @param <D> the last type variable after substitution.
-   * @return a factory to lift the TypeEq instances into any type constructor.
-   */
-  public final <C, D> Lift2TypeEq<A, C, B, D> lift2(TypeEq<C, D> cd) {
-    return new Lift2TypeEq<A, C, B, D>(this, cd);
+interface Lift3<f, A, B, C, D, E, X> extends __7<Lift3.µ, f, A, B, C, D, E, X> {
+  enum µ {}
+
+  TypeEq<__<__<__<f, A>, B>, C>, __<__<__<f, D>, E>, X>> __();
+
+  static <f, A, B, C, D, E, X> Lift3<f, A, B, C, D, E, X> narrow(__<__<__<__<__<__<__<Lift3.µ, f>, A>, B>, C>, D>, E>, X> lift3) {
+    return (Lift3<f, A, B, C, D, E, X>) lift3;
   }
-
-  /**
-   * The type equality can be lifted into any type constructor, at any position.
-   *
-   * @param <f> a type constructor witness.
-   * @param <C> the before last type variable (not substituted).
-   * @param <D> the last type variable (not substituted).
-   * @return the type equality in the context of the specified type constructor.
-   */
-  public final <f, C, D> TypeEq<__<__<__<f, A>, C>, D>, __<__<__<f, B>, C>, D>> lift3() {
-    return Lift3.ofHkt(subst(new Lift3<>(TypeEq.<__<__<__<f, A>, C>, D>>refl()))).unlift3;
-  }
-
-  /**
-   * Type equalities can be lifted into any type constructor, at any positions.
-   *
-   * @param cd a type equality witness for before last type variable of any type constructor.
-   * @param ef a type equality witness for last type variable of any type constructor.
-   * @param <C> the before last type variable before substitution.
-   * @param <D> the before last type variable after substitution.
-   * @param <E> the last type variable before substitution.
-   * @param <F> the last type variable after substitution.
-   * @return a factory to lift the TypeEq instances into any type constructor.
-   */
-  public final <C, D, E, F> Lift3TypeEq<A, C, E, B, D, F> lift3(TypeEq<C, D> cd, TypeEq<E, F> ef) {
-    return new Lift3TypeEq<A, C, E, B, D, F>(this, cd, ef);
-  }
-
-  /**
-   * Type inference helper class:
-   * allow to lift two TypeEq instances into any type constructor.
-   *
-   * @param <A> the before last type variable before substitution.
-   * @param <C> the last type variable before substitution.
-   * @param <B> the before last type variable after substitution.
-   * @param <D> the last type variable after substitution.
-   */
-  public static final class Lift2TypeEq<A, C, B, D> {
-
-    private final TypeEq<A, B> ab;
-
-    private final TypeEq<C, D> cd;
-
-    Lift2TypeEq(TypeEq<A, B> ab, TypeEq<C, D> cd) {
-      this.ab = ab;
-      this.cd = cd;
-    }
-
-    /**
-     * Lift two TypeEq instances into a type constructor.
-     *
-     * @param <f> a type constructor witness.
-     * @return the type equalities in the context of the type constructor.
-     */
-    public <f> TypeEq<__<__<f, A>, C>, __<__<f, B>, D>> lift() {
-
-      TypeEq<__<__<f, A>, C>, __<__<f, B>, C>> abLift = ab.lift2();
-      TypeEq<__<__<f, B>, C>, __<__<f, B>, D>> cdLift = cd.lift();
-
-      return new TypeEq<__<__<f, A>, C>, __<__<f, B>, D>>() {
-        @Override public <f2> __<f2, __<__<f, B>, D>> subst(__<f2, __<__<f, A>, C>> fa) {
-          return cdLift.subst(abLift.subst(fa));
-        }
-      };
-    }
-  }
-
-  /**
-   * Type inference helper class:
-   * allow to lift three TypeEq instances into any type constructor.
-   *
-   * @param <A> the antepenultimate type variable before substitution.
-   * @param <C> the before last type variable before substitution.
-   * @param <E> the last type variable before substitution.
-   * @param <B> the antepenultimate type variable after substitution.
-   * @param <D> the before last type variable after substitution.
-   * @param <F> the last type variable after substitution.
-   */
-  public static final class Lift3TypeEq<A, C, E, B, D, F> {
-
-    private final TypeEq<A, B> ab;
-
-    private final TypeEq<C, D> cd;
-
-    private final TypeEq<E, F> ef;
-
-    Lift3TypeEq(TypeEq<A, B> ab, TypeEq<C, D> cd, TypeEq<E, F> ef) {
-      this.ab = ab;
-      this.cd = cd;
-      this.ef = ef;
-    }
-
-    /**
-     * Lift three TypeEq instances into a type constructor.
-     *
-     * @param <f> a type constructor witness.
-     * @return the type equalities in the context of the type constructor.
-     */
-    public <f> TypeEq<__<__<__<f, A>, C>, E>, __<__<__<f, B>, D>, F>> lift() {
-
-      TypeEq<__<__<__<f, A>, C>, E>, __<__<__<f, B>, C>, E>> abLift = ab.lift3();
-      TypeEq<__<__<__<f, B>, C>, E>, __<__<__<f, B>, D>, E>> cdLift = cd.lift2();
-      TypeEq<__<__<__<f, B>, D>, E>, __<__<__<f, B>, D>, F>> efLift = ef.lift();
-
-      return new TypeEq<__<__<__<f, A>, C>, E>, __<__<__<f, B>, D>, F>>() {
-        @Override public <f2> __<f2, __<__<__<f, B>, D>, F>> subst(__<f2, __<__<__<f, A>, C>, E>> fa) {
-          return efLift.subst(cdLift.subst(abLift.subst(fa)));
-        }
-      };
-    }
-  }
-
-  private static class Identity<A> implements __<Identity.µ, A> {
-
-    final A runIdentity;
-
-    Identity(A runIdentity) {
-      this.runIdentity = runIdentity;
-    }
-
-    static <A> Identity<A> ofHkt(__<µ, A> hkId) {
-      return (Identity<A>) hkId;
-    }
-
-    enum µ {}
-  }
-
-  private static class Symm<A, B> implements __2<Symm.µ, A, B> {
-
-    final TypeEq<B, A> typeEq;
-
-    Symm(TypeEq<B, A> typeEq) {
-      this.typeEq = typeEq;
-    }
-
-    static <A, B> Symm<A, B> ofHkt(__<__<µ, A>, B> hkSymm) {
-      return (Symm<A, B>) hkSymm;
-    }
-
-    enum µ {}
-  }
-
-  private static class Lift<f, A, B> implements __3<Lift.µ, f, A, B> {
-
-    final TypeEq<__<f, A>, __<f, B>> unlift;
-
-    Lift(TypeEq<__<f, A>, __<f, B>> unlift) {
-      this.unlift = unlift;
-    }
-
-    static <f, A, B> Lift<f, A, B> ofHkt(__<__<__<µ, f>, A>, B> hkLift) {
-      return (Lift<f, A, B>) hkLift;
-    }
-
-    enum µ {}
-  }
-
-  private static class Lift2<f, C, A, B> implements __4<Lift2.µ, f, C, A, B> {
-
-    final TypeEq<__<__<f, A>, C>, __<__<f, B>, C>> unlift2;
-
-    Lift2(TypeEq<__<__<f, A>, C>, __<__<f, B>, C>> unlift2) {
-      this.unlift2 = unlift2;
-    }
-
-    static <f, C, A, B> Lift2<f, C, A, B> ofHkt(__<__<__<__<µ, f>, C>, A>, B> hkLift2) {
-      return (Lift2<f, C, A, B>) hkLift2;
-    }
-
-    enum µ {}
-  }
-
-  private static class Lift3<f, C, D, A, B> implements __5<Lift3.µ, f, C, D, A, B> {
-
-    final TypeEq<__<__<__<f, A>, C>, D>, __<__<__<f, B>, C>, D>> unlift3;
-
-    Lift3(TypeEq<__<__<__<f, A>, C>, D>, __<__<__<f, B>, C>, D>> unlift3) {
-      this.unlift3 = unlift3;
-    }
-
-    static <f, C, D, A, B> Lift3<f, C, D, A, B> ofHkt(__<__<__<__<__<µ, f>, C>, D>, A>, B> hkLift3) {
-      return (Lift3<f, C, D, A, B>) hkLift3;
-    }
-
-    enum µ {}
-  }
-
 }

--- a/src/main/java/org/derive4j/hkt/TypeEq.java
+++ b/src/main/java/org/derive4j/hkt/TypeEq.java
@@ -13,28 +13,149 @@ package org.derive4j.hkt;
  * @see <a href="http://typelevel.org/blog/2014/09/20/higher_leibniz.html">Higher TypeEq</a>
  * @see <a href="https://github.com/ekmett/eq">Leibnizian type equality in Haskell</a>
  */
-public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
+@SuppressWarnings("Convert2MethodRef")
+public interface TypeEq<A, B> extends  __2<TypeEq.µ, A, B> {
+  /** Type constructor witness of TypeEq. */
+  enum µ {}
 
-  /** Serve as type constructor witness of TypeEq. */
-  public enum µ {}
+  /**
+   * Leibnizian equality states that two things are equal if you can substitute one for the other in all contexts.
+   *
+   * @param fa a term whose type last parameter is {@link A}.
+   * @param <f> type constructor witness of {@code fa} type.
+   * @return the input value with {@link A} substituted by {@link B} in its type.
+   */
+  <f> __<f, B> subst(__<f, A> fa);
 
-  private TypeEq() {
+  /**
+   * If two things are equal you can convert one to the other (safe cast).
+   *
+   * @param a a value of type {@link A} that will be coerced into type {@link B}.
+   * @return the same value, after type coercion.
+   */
+  default B coerce(A a) {
+    return Id.narrow(subst((Id<A>) () -> a)).__();
+  }
+
+  /**
+   * Equality is transitive.
+   *
+   * @param that another TypeEq to compose with.
+   * @param <C> left operand of the transitive type equality.
+   * @return the composition of the TypeEq instances.
+   */
+  default <C> TypeEq<C, B> compose(TypeEq<C, A> that) {
+    return TypeEq.ofHkt(subst(that));
+  }
+
+  /**
+   * Equality is transitive.
+   *
+   * @param that another TypeEq to be composed with.
+   * @param <C> right operand of the transitive type equality.
+   * @return the composition of the TypeEq instances.
+   */
+  default <C> TypeEq<A, C> andThen(TypeEq<B, C> that) {
+    return that.compose(this);
+  }
+
+  /**
+   * Equality is symmetric.
+   *
+   * @return the type equality seen from the other side.
+   */
+  default TypeEq<B, A> symm() {
+    final Symm<A, A> symm = () -> refl();
+
+    return Symm.narrow(subst(symm)).__();
+  }
+
+  /**
+   * The type equality can be lifted into any type constructor.
+   *
+   * @param <f> a type constructor witness.
+   * @return the type equality in the context of the specified type constructor.
+   */
+  default <f> TypeEq<__<f, A>, __<f, B>> lift() {
+    final Lift<f, A, A> _refl = () -> refl();
+
+    return Lift.narrow(subst(_refl)).__();
+  }
+
+  /**
+   * The type equality can be lifted into any type constructor, at any position.
+   *
+   * @param <f> a type constructor witness.
+   * @param <C> the last type variable (not substituted).
+   * @return the type equality in the context of the specified type constructor.
+   */
+  default <f, C> TypeEq<__<__<f, A>, C>, __<__<f, B>, C>> lift2() {
+    return lift2(refl());
+  }
+
+  /**
+   * Type equalities can be lifted into any type constructor, at any positions.
+   *
+   * @param cd a type equality witness for last type variable of any type constructor.
+   * @param <C> the last type variable before substitution.
+   * @param <D> the last type variable after substitution.
+   * @return a factory to lift the TypeEq instances into any type constructor.
+   */
+  default <f, C, D> TypeEq<__<__<f, A>, C>, __<__<f, B>, D>> lift2(TypeEq<C, D> cd) {
+    final Lift2_1<f, A, C, A> _refl = () -> refl();
+
+    final Lift2_1<f, A, C, B> lift2_1 = Lift2_1.narrow(subst(_refl));
+
+    final Lift2<f, A, C, B, C> lift2 = () -> lift2_1.__();
+
+    return Lift2.narrow(cd.subst(lift2)).__();
+  }
+
+  /**
+   * The type equality can be lifted into any type constructor, at any position.
+   *
+   * @param <f> a type constructor witness.
+   * @param <C> the before last type variable (not substituted).
+   * @param <D> the last type variable (not substituted).
+   * @return the type equality in the context of the specified type constructor.
+   */
+  default <f, C, D> TypeEq<__<__<__<f, A>, C>, D>, __<__<__<f, B>, C>, D>> lift3() {
+    return lift3(refl(), refl());
+  }
+
+  /**
+   * Type equalities can be lifted into any type constructor, at any positions.
+   *
+   * @param cd a type equality witness for before last type variable of any type constructor.
+   * @param ef a type equality witness for last type variable of any type constructor.
+   * @param <C> the before last type variable before substitution.
+   * @param <D> the before last type variable after substitution.
+   * @param <E> the last type variable before substitution.
+   * @param <F> the last type variable after substitution.
+   * @return a factory to lift the TypeEq instances into any type constructor.
+   */
+  default <f, C, D, E, F> TypeEq<__<__<__<f, A>, C>, E>, __<__<__<f, B>, D>, F>> lift3(TypeEq<C, D> cd
+    , TypeEq<E, F> ef) {
+    final Lift3_1<f, A, C, E, A> _refl = () -> refl();
+
+    final Lift3_1<f, A, C, E, B> lift3_1 = Lift3_1.narrow(subst(_refl));
+
+    final Lift3_2<f, A, C, E, B, C> lift3_2 = () -> lift3_1.__();
+
+    final Lift3_2<f, A, C, E, B, D> lift3_2_1 = Lift3_2.narrow(cd.subst(lift3_2));
+
+    final Lift3<f, A, C, E, B, D, E> lift3 = () -> lift3_2_1.__();
+
+    return Lift3.narrow(ef.subst(lift3)).__();
   }
 
   /**
    * Equality is reflexive: a type is equal to itself.
    *
-   * @param <A> any type.
+   * @param <T> any type.
    * @return a TypeEq representing the reflexive equality.
    */
-  public static <A> TypeEq<A, A> refl() {
-    // The only possible implementation, the identity:
-    return new TypeEq<A, A>() {
-      @Override public <f> __<f, A> subst(final __<f, A> fa) {
-        return fa;
-      }
-    };
-  }
+  static <T> TypeEq<T, T> refl() { return HktId::id; }
 
   /**
    * Recover the concrete type of a higher kinded TypeEq value.
@@ -45,7 +166,7 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @param <B> a type {@link B} which is guaranteed to be same as {@link A}.
    * @return the same TypeEq, casted to the corresponding concrete type.
    */
-  public static <A, B> TypeEq<A, B> ofHkt(__<__<TypeEq.µ, A>, B> hkTypeEq) {
+  static <A, B> TypeEq<A, B> ofHkt(__<__<TypeEq.µ, A>, B> hkTypeEq) {
     return (TypeEq<A, B>) hkTypeEq;
   }
 
@@ -60,14 +181,14 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <A, B> TypeEq<__<__<TypeEq.µ, A>, B>, TypeEq<A, B>> hkt() {
-    return (TypeEq) refl();
+  static <A, B> TypeEq<__<__<TypeEq.µ, A>, B>, TypeEq<A, B>> hkt() {
+    return (TypeEq) TypeEq.refl();
   }
 
   /**
    * Safe cast to __2. (guaranteed by the hkt type checker).
    */
-  public static <f, A, B> __2<f, A, B> as__2(__<__<f, A>, B> fab) {
+  static <f, A, B> __2<f, A, B> as__2(__<__<f, A>, B> fab) {
     return (__2<f, A, B>) fab;
   }
 
@@ -148,7 +269,7 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
   /**
    * Safe cast to __6. (guaranteed by the hkt type checker).
    */
-  public static <f, A, B, C, D, E, F> __6<f, A, B, C, D, E, F> as__6(__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F> fabcdef) {
+  static <f, A, B, C, D, E, F> __6<f, A, B, C, D, E, F> as__6(__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F> fabcdef) {
     return (__6<f, A, B, C, D, E, F>) fabcdef;
   }
 
@@ -160,15 +281,15 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <f, A, B, C, D, E, F> TypeEq<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, __6<f, A, B, C, D, E, F>> __6() {
+  static <f, A, B, C, D, E, F> TypeEq<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, __6<f, A, B, C, D, E, F>> __6() {
     return (TypeEq) TypeEq.refl();
   }
 
   /**
    * Safe cast to __7. (guaranteed by the hkt type checker).
    */
-  public static <f, A, B, C, D, E, F, G> __7<f, A, B, C, D, E, F, G> as__7(__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>
-      fabcdefg) {
+  static <f, A, B, C, D, E, F, G> __7<f, A, B, C, D, E, F, G> as__7(__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>
+                                                                      fabcdefg) {
     return (__7<f, A, B, C, D, E, F, G>) fabcdefg;
   }
 
@@ -180,7 +301,7 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <f, A, B, C, D, E, F, G> TypeEq<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, __7<f, A, B, C, D, E, F, G>> __7() {
+  static <f, A, B, C, D, E, F, G> TypeEq<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, __7<f, A, B, C, D, E, F, G>> __7() {
     return (TypeEq) TypeEq.refl();
   }
 
@@ -188,7 +309,7 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
   /**
    * Safe cast to __8. (guaranteed by the hkt type checker).
    */
-  public static <f, A, B, C, D, E, F, G, H> __8<f, A, B, C, D, E, F, G, H> as__8(__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H> fabcdefgh) {
+  static <f, A, B, C, D, E, F, G, H> __8<f, A, B, C, D, E, F, G, H> as__8(__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H> fabcdefgh) {
     return (__8<f, A, B, C, D, E, F, G, H>) fabcdefgh;
   }
 
@@ -200,7 +321,7 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <f, A, B, C, D, E, F, G, H> TypeEq<__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H>, __8<f, A, B, C, D, E, F, G, H>> __8() {
+  static <f, A, B, C, D, E, F, G, H> TypeEq<__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H>, __8<f, A, B, C, D, E, F, G, H>> __8() {
     return (TypeEq) TypeEq.refl();
   }
 
@@ -208,7 +329,7 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
   /**
    * Safe cast to __9. (guaranteed by the hkt type checker).
    */
-  public static <f, A, B, C, D, E, F, G, H, I> __9<f, A, B, C, D, E, F, G, H, I> as__9(__<__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H>, I> fabcdefghi) {
+  static <f, A, B, C, D, E, F, G, H, I> __9<f, A, B, C, D, E, F, G, H, I> as__9(__<__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H>, I> fabcdefghi) {
     return (__9<f, A, B, C, D, E, F, G, H, I>) fabcdefghi;
   }
 
@@ -220,281 +341,91 @@ public abstract class TypeEq<A, B> implements __2<TypeEq.µ, A, B> {
    * @return a TypeEq instance witness of the type equality.
    */
   @SuppressWarnings("unchecked")
-  public static <f, A, B, C, D, E, F, G, H, I> TypeEq<__<__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H>, I>, __9<f, A, B, C, D, E, F, G, H, I>> __9() {
+  static <f, A, B, C, D, E, F, G, H, I> TypeEq<__<__<__<__<__<__<__<__<__<f, A>, B>, C>, D>, E>, F>, G>, H>, I>, __9<f, A, B, C, D, E, F, G, H, I>> __9() {
     return (TypeEq) TypeEq.refl();
   }
+}
 
-  /**
-   * Leibnizian equality states that two things are equal if you can substitute one for the other in all contexts.
-   *
-   * @param fa a term whose type last parameter is {@link A}.
-   * @param <f> type constructor witness of {@code fa} type.
-   * @return the input value with {@link A} substituted by {@link B} in its type.
-   */
-  public abstract <f> __<f, B> subst(__<f, A> fa);
+// ################ Type inference helpers
 
-  /**
-   * If two things are equal you can convert one to the other (safe cast).
-   *
-   * @param a a value of type {@link A} that will be coerced into type {@link B}.
-   * @return the same value, after type coercion.
-   */
-  public final B coerce(A a) {
-    return Identity.ofHkt(subst(new Identity<>(a))).runIdentity;
+interface HktId {
+  static <f, T> __<f, T> id(__<f, T> ft) { return ft; }
+}
+
+interface Id<A> extends __<Id.µ, A> {
+  enum µ {}
+
+  A __();
+
+  static <A> Id<A> narrow(__<Id.µ, A> a) { return (Id<A>) a; }
+}
+
+interface Symm<A, B> extends __2<Symm.µ, A, B> {
+  enum µ {}
+
+  TypeEq<B, A> __();
+
+  static <f, A, B> Symm<A, B> narrow(__<__<Symm.µ, A>, B> _lift) {
+    return (Symm<A, B>) _lift;
   }
+}
 
-  /**
-   * Equality is transitive.
-   *
-   * @param that another TypeEq to compose with.
-   * @param <C> left operand of the transitive type equality.
-   * @return the composition of the TypeEq instances.
-   */
-  public final <C> TypeEq<C, B> compose(TypeEq<C, A> that) {
-    return new TypeEq<C, B>() {
-      @Override public <f> __<f, B> subst(__<f, C> fa) {
-        return TypeEq.this.subst(that.subst(fa));
-      }
-    };
+interface Lift<f, A, B> extends __3<Lift.µ, f, A, B> {
+  enum µ {}
+
+  TypeEq<__<f, A>, __<f, B>> __();
+
+  static <f, A, X> Lift<f, A, X> narrow(__<__<__<Lift.µ, f>, A>, X> _lift) {
+    return (Lift<f, A, X>) _lift;
   }
+}
 
-  /**
-   * Equality is transitive.
-   *
-   * @param that another TypeEq to be composed with.
-   * @param <C> right operand of the transitive type equality.
-   * @return the composition of the TypeEq instances.
-   */
-  public final <C> TypeEq<A, C> andThen(TypeEq<B, C> that) {
-    return that.compose(this);
+interface Lift2_1<f, A, B, X> extends __4<Lift2_1.µ, f, A, B, X> {
+  enum µ {}
+
+  TypeEq<__<__<f, A>, B>, __<__<f, X>, B>> __();
+
+  static <f, A, B, X> Lift2_1<f, A, B, X> narrow(__<__<__<__<Lift2_1.µ, f>, A>, B>, X> lift1) {
+    return (Lift2_1<f, A, B, X>) lift1;
   }
+}
 
-  /**
-   * Equality is symmetric.
-   *
-   * @return the type equality seen from the other side.
-   */
-  public final TypeEq<B, A> symm() {
-    return Symm.ofHkt(subst(new Symm<>(refl()))).typeEq;
+interface Lift2<f, A, B, C, X> extends __5<Lift2.µ, f, A, B, C, X>  {
+  enum µ {}
+
+  TypeEq<__<__<f, A>, B>, __<__<f, C>, X>> __();
+
+  static <f, A, B, C, X> Lift2<f, A, B, C, X> narrow(__<__<__<__<__<Lift2.µ, f>, A>, B>, C>, X> lift2) {
+    return (Lift2<f, A, B, C, X>) lift2;
   }
+}
 
-  /**
-   * The type equality can be lifted into any type constructor.
-   *
-   * @param <f> a type constructor witness.
-   * @return the type equality in the context of the specified type constructor.
-   */
-  public final <f> TypeEq<__<f, A>, __<f, B>> lift() {
-    return Lift.ofHkt(subst(new Lift<>(TypeEq.<__<f, A>>refl()))).unlift;
+interface Lift3_1<f, A, B, C, X> extends __5<Lift3_1.µ, f, A, B, C, X> {
+  enum µ {}
+
+  TypeEq<__<__<__<f, A>, B>, C>, __<__<__<f, X>, B>, C>> __();
+
+  static <f, A, B, C, X> Lift3_1<f, A, B, C, X> narrow(__<__<__<__<__<Lift3_1.µ, f>, A>, B>, C>, X> lift3) {
+    return (Lift3_1<f, A, B, C, X>) lift3;
   }
+}
 
-  /**
-   * The type equality can be lifted into any type constructor, at any position.
-   *
-   * @param <f> a type constructor witness.
-   * @param <C> the last type variable (not substituted).
-   * @return the type equality in the context of the specified type constructor.
-   */
-  public final <f, C> TypeEq<__<__<f, A>, C>, __<__<f, B>, C>> lift2() {
-    return Lift2.ofHkt(subst(new Lift2<>(TypeEq.<__<__<f, A>, C>>refl()))).unlift2;
+interface Lift3_2<f, A, B, C, D, X> extends __6<Lift3_2.µ, f, A, B, C, D, X> {
+  enum µ {}
+
+  TypeEq<__<__<__<f, A>, B>, C>, __<__<__<f, D>, X>, C>> __();
+
+  static <f, A, B, C, D, X> Lift3_2<f, A, B, C, D, X> narrow(__<__<__<__<__<__<Lift3_2.µ, f>, A>, B>, C>, D>, X> lift3) {
+    return (Lift3_2<f, A, B, C, D, X>) lift3;
   }
+}
 
-  /**
-   * Type equalities can be lifted into any type constructor, at any positions.
-   *
-   * @param cd a type equality witness for last type variable of any type constructor.
-   * @param <C> the last type variable before substitution.
-   * @param <D> the last type variable after substitution.
-   * @return a factory to lift the TypeEq instances into any type constructor.
-   */
-  public final <C, D> Lift2TypeEq<A, C, B, D> lift2(TypeEq<C, D> cd) {
-    return new Lift2TypeEq<A, C, B, D>(this, cd);
+interface Lift3<f, A, B, C, D, E, X> extends __7<Lift3.µ, f, A, B, C, D, E, X> {
+  enum µ {}
+
+  TypeEq<__<__<__<f, A>, B>, C>, __<__<__<f, D>, E>, X>> __();
+
+  static <f, A, B, C, D, E, X> Lift3<f, A, B, C, D, E, X> narrow(__<__<__<__<__<__<__<Lift3.µ, f>, A>, B>, C>, D>, E>, X> lift3) {
+    return (Lift3<f, A, B, C, D, E, X>) lift3;
   }
-
-  /**
-   * The type equality can be lifted into any type constructor, at any position.
-   *
-   * @param <f> a type constructor witness.
-   * @param <C> the before last type variable (not substituted).
-   * @param <D> the last type variable (not substituted).
-   * @return the type equality in the context of the specified type constructor.
-   */
-  public final <f, C, D> TypeEq<__<__<__<f, A>, C>, D>, __<__<__<f, B>, C>, D>> lift3() {
-    return Lift3.ofHkt(subst(new Lift3<>(TypeEq.<__<__<__<f, A>, C>, D>>refl()))).unlift3;
-  }
-
-  /**
-   * Type equalities can be lifted into any type constructor, at any positions.
-   *
-   * @param cd a type equality witness for before last type variable of any type constructor.
-   * @param ef a type equality witness for last type variable of any type constructor.
-   * @param <C> the before last type variable before substitution.
-   * @param <D> the before last type variable after substitution.
-   * @param <E> the last type variable before substitution.
-   * @param <F> the last type variable after substitution.
-   * @return a factory to lift the TypeEq instances into any type constructor.
-   */
-  public final <C, D, E, F> Lift3TypeEq<A, C, E, B, D, F> lift3(TypeEq<C, D> cd, TypeEq<E, F> ef) {
-    return new Lift3TypeEq<A, C, E, B, D, F>(this, cd, ef);
-  }
-
-  /**
-   * Type inference helper class:
-   * allow to lift two TypeEq instances into any type constructor.
-   *
-   * @param <A> the before last type variable before substitution.
-   * @param <C> the last type variable before substitution.
-   * @param <B> the before last type variable after substitution.
-   * @param <D> the last type variable after substitution.
-   */
-  public static final class Lift2TypeEq<A, C, B, D> {
-
-    private final TypeEq<A, B> ab;
-
-    private final TypeEq<C, D> cd;
-
-    Lift2TypeEq(TypeEq<A, B> ab, TypeEq<C, D> cd) {
-      this.ab = ab;
-      this.cd = cd;
-    }
-
-    /**
-     * Lift two TypeEq instances into a type constructor.
-     *
-     * @param <f> a type constructor witness.
-     * @return the type equalities in the context of the type constructor.
-     */
-    public <f> TypeEq<__<__<f, A>, C>, __<__<f, B>, D>> lift() {
-
-      TypeEq<__<__<f, A>, C>, __<__<f, B>, C>> abLift = ab.lift2();
-      TypeEq<__<__<f, B>, C>, __<__<f, B>, D>> cdLift = cd.lift();
-
-      return new TypeEq<__<__<f, A>, C>, __<__<f, B>, D>>() {
-        @Override public <f2> __<f2, __<__<f, B>, D>> subst(__<f2, __<__<f, A>, C>> fa) {
-          return cdLift.subst(abLift.subst(fa));
-        }
-      };
-    }
-  }
-
-  /**
-   * Type inference helper class:
-   * allow to lift three TypeEq instances into any type constructor.
-   *
-   * @param <A> the antepenultimate type variable before substitution.
-   * @param <C> the before last type variable before substitution.
-   * @param <E> the last type variable before substitution.
-   * @param <B> the antepenultimate type variable after substitution.
-   * @param <D> the before last type variable after substitution.
-   * @param <F> the last type variable after substitution.
-   */
-  public static final class Lift3TypeEq<A, C, E, B, D, F> {
-
-    private final TypeEq<A, B> ab;
-
-    private final TypeEq<C, D> cd;
-
-    private final TypeEq<E, F> ef;
-
-    Lift3TypeEq(TypeEq<A, B> ab, TypeEq<C, D> cd, TypeEq<E, F> ef) {
-      this.ab = ab;
-      this.cd = cd;
-      this.ef = ef;
-    }
-
-    /**
-     * Lift three TypeEq instances into a type constructor.
-     *
-     * @param <f> a type constructor witness.
-     * @return the type equalities in the context of the type constructor.
-     */
-    public <f> TypeEq<__<__<__<f, A>, C>, E>, __<__<__<f, B>, D>, F>> lift() {
-
-      TypeEq<__<__<__<f, A>, C>, E>, __<__<__<f, B>, C>, E>> abLift = ab.lift3();
-      TypeEq<__<__<__<f, B>, C>, E>, __<__<__<f, B>, D>, E>> cdLift = cd.lift2();
-      TypeEq<__<__<__<f, B>, D>, E>, __<__<__<f, B>, D>, F>> efLift = ef.lift();
-
-      return new TypeEq<__<__<__<f, A>, C>, E>, __<__<__<f, B>, D>, F>>() {
-        @Override public <f2> __<f2, __<__<__<f, B>, D>, F>> subst(__<f2, __<__<__<f, A>, C>, E>> fa) {
-          return efLift.subst(cdLift.subst(abLift.subst(fa)));
-        }
-      };
-    }
-  }
-
-  private static class Identity<A> implements __<Identity.µ, A> {
-
-    final A runIdentity;
-
-    Identity(A runIdentity) {
-      this.runIdentity = runIdentity;
-    }
-
-    static <A> Identity<A> ofHkt(__<µ, A> hkId) {
-      return (Identity<A>) hkId;
-    }
-
-    enum µ {}
-  }
-
-  private static class Symm<A, B> implements __2<Symm.µ, A, B> {
-
-    final TypeEq<B, A> typeEq;
-
-    Symm(TypeEq<B, A> typeEq) {
-      this.typeEq = typeEq;
-    }
-
-    static <A, B> Symm<A, B> ofHkt(__<__<µ, A>, B> hkSymm) {
-      return (Symm<A, B>) hkSymm;
-    }
-
-    enum µ {}
-  }
-
-  private static class Lift<f, A, B> implements __3<Lift.µ, f, A, B> {
-
-    final TypeEq<__<f, A>, __<f, B>> unlift;
-
-    Lift(TypeEq<__<f, A>, __<f, B>> unlift) {
-      this.unlift = unlift;
-    }
-
-    static <f, A, B> Lift<f, A, B> ofHkt(__<__<__<µ, f>, A>, B> hkLift) {
-      return (Lift<f, A, B>) hkLift;
-    }
-
-    enum µ {}
-  }
-
-  private static class Lift2<f, C, A, B> implements __4<Lift2.µ, f, C, A, B> {
-
-    final TypeEq<__<__<f, A>, C>, __<__<f, B>, C>> unlift2;
-
-    Lift2(TypeEq<__<__<f, A>, C>, __<__<f, B>, C>> unlift2) {
-      this.unlift2 = unlift2;
-    }
-
-    static <f, C, A, B> Lift2<f, C, A, B> ofHkt(__<__<__<__<µ, f>, C>, A>, B> hkLift2) {
-      return (Lift2<f, C, A, B>) hkLift2;
-    }
-
-    enum µ {}
-  }
-
-  private static class Lift3<f, C, D, A, B> implements __5<Lift3.µ, f, C, D, A, B> {
-
-    final TypeEq<__<__<__<f, A>, C>, D>, __<__<__<f, B>, C>, D>> unlift3;
-
-    Lift3(TypeEq<__<__<__<f, A>, C>, D>, __<__<__<f, B>, C>, D>> unlift3) {
-      this.unlift3 = unlift3;
-    }
-
-    static <f, C, D, A, B> Lift3<f, C, D, A, B> ofHkt(__<__<__<__<__<µ, f>, C>, D>, A>, B> hkLift3) {
-      return (Lift3<f, C, D, A, B>) hkLift3;
-    }
-
-    enum µ {}
-  }
-
 }


### PR DESCRIPTION
As @jbgi and I discussed on gitter. I wonder if we could get rid of a number of casts by instantiating TypeEq through method references....